### PR TITLE
Added simple docker file to run release in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM openjdk:8
+
+ENV JAR_VERSION 1.0.5-test.5
+ENV JAR_DOWNLOAD_URL https://github.com/fabianonline/telegram_backup/releases/download/${JAR_VERSION}/telegram_backup.jar
+
+RUN apt-get update -y && apt-get install -y curl && \
+    curl -L "https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.1.3_amd64" -o /bin/dumb-init && \
+    curl -L $JAR_DOWNLOAD_URL -o telegram_backup.jar && mkdir /data/ && chmod +x /bin/dumb-init
+
+ENTRYPOINT ["/bin/dumb-init", "--"]
+
+CMD ["java", "-jar", "telegram_backup.jar", "--target", "/data/", "--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  tg-dl:
+    build:
+      context: .
+    restart: "unless-stopped"
+    volumes:
+      - /data/telegram-downloader:/data  # host server path : docker container path
+    command: ["java", "-jar", "telegram_backup.jar", "--target", "/data/"]


### PR DESCRIPTION
It downloads the zip from the releases, instead of compiling it,
but it allows to run it on a docker server.

So could (should) be improved but maybe is a starting point.

Usage something similar to this:
```shell
docker build . -t tg-dl:1.0.5-test.5
docker run -it --rm --name=tg_dl -v "/data/telegram-downloader:/data" tg-dl:1.0.5-test.5 
/bin/bash
# now you should be inside the container
java -jar telegram_backup.jar --target '/data/' --help
```