### PR TITLE
Properly handle FLOOD_WAIT in media download phase

### DIFF
--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -431,6 +431,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 						if (e.getCode() == 420) { // FLOOD_WAIT
 							try_again = true
 							Utils.obeyFloodWaitException(e)
+							continue // response is null since we didn't actually receive any data. Skip the rest of this iteration and try again.
 						} else if (e.getCode() == 400) {
 							//Somehow this file is broken. No idea why. Let's skip it for now
 							return false

--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -450,7 +450,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 					} catch (e: InterruptedException) {
 					}
 
-				} while (offset < size && (response!!.getBytes().getData().size > 0 || try_again))
+				} while (offset < size && (try_again || response!!.getBytes().getData().size > 0))
 				fos.close()
 				if (offset < size) {
 					System.out.println("Requested file $target with $size bytes, but got only $offset bytes.")

--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -316,7 +316,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 			try {
 				_downloadMedia()
 			} catch (e: RpcErrorException) {
-				if (e.getTag().startsWith("420: FLOOD_WAIT_")) {
+				if (e.getCode() == 420) { // FLOOD_WAIT
 					completed = false
 					Utils.obeyFloodWaitException(e)
 				} else {
@@ -428,7 +428,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 					try {
 						response = download_client!!.executeRpcQuery(req, dcID) as TLFile
 					} catch (e: RpcErrorException) {
-						if (e.getTag().startsWith("420: FLOOD_WAIT_")) {
+						if (e.getCode() == 420) { // FLOOD_WAIT
 							try_again = true
 							Utils.obeyFloodWaitException(e)
 						} else if (e.getCode() == 400) {


### PR DESCRIPTION
Tested and fixes issue #84 

Screenshot from that issue:
![2018-01-31 12 58 57](https://user-images.githubusercontent.com/3837873/35647165-83c1c088-0686-11e8-8aaa-8bf797d04114.jpg)