### PR TITLE
(not ready for merging yet) update dependency and telegram api layer from 53 to 66

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ compileKotlin {
 		
 
 dependencies {
-	compile('com.github.badoualy:kotlogram:1.0.0-RC3') {
+	compile('com.github.badoualy:kotlogram:1.0.0-RC1') {
 		exclude module: 'slf4j-simple'
 	}
 	compile 'org.xerial:sqlite-jdbc:3.16.1'

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ compileKotlin {
 		
 
 dependencies {
-	compile('com.github.badoualy:kotlogram:666a81ef9d6707f117a3fecc2d21c91d51c7d075') {
+	compile('com.github.badoualy:kotlogram:1.0.0-RC3') {
 		exclude module: 'slf4j-simple'
 	}
 	compile 'org.xerial:sqlite-jdbc:3.16.1'

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ compileKotlin {
 		
 
 dependencies {
-	compile('com.github.badoualy:kotlogram:1.0.0-RC1') {
+	compile('com.github.badoualy:kotlogram:1.0.0-RC2') {
 		exclude module: 'slf4j-simple'
 	}
 	compile 'org.xerial:sqlite-jdbc:3.16.1'

--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -431,6 +431,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 						if (e.getCode() == 420) { // FLOOD_WAIT
 							try_again = true
 							Utils.obeyFloodWaitException(e)
+							continue // response is null since we didn't actually receive any data. Skip the rest of this iteration and try again.
 						} else if (e.getCode() == 400) {
 							//Somehow this file is broken. No idea why. Let's skip it for now
 							return false

--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -111,6 +111,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 		System.out.println("Downloading most recent dialogs... ")
 		var max_message_id = 0
 		val dialogs = client!!.messagesGetDialogs(
+			true,
 			0,
 			0,
 			TLInputPeerEmpty(),

--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -450,7 +450,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 					} catch (e: InterruptedException) {
 					}
 
-				} while (offset < size && (response!!.getBytes().getData().size > 0 || try_again))
+				} while (offset < size && (try_again || response!!.getBytes().getData().size > 0))
 				fos.close()
 				if (offset < size) {
 					System.out.println("Requested file $target with $size bytes, but got only $offset bytes.")

--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -316,7 +316,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 			try {
 				_downloadMedia()
 			} catch (e: RpcErrorException) {
-				if (e.getTag().startsWith("420: FLOOD_WAIT_")) {
+				if (e.getCode() == 420) { // FLOOD_WAIT
 					completed = false
 					Utils.obeyFloodWaitException(e)
 				} else {
@@ -428,7 +428,7 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 					try {
 						response = download_client!!.executeRpcQuery(req, dcID) as TLFile
 					} catch (e: RpcErrorException) {
-						if (e.getTag().startsWith("420: FLOOD_WAIT_")) {
+						if (e.getCode() == 420) { // FLOOD_WAIT
 							try_again = true
 							Utils.obeyFloodWaitException(e)
 						} else if (e.getCode() == 400) {

--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -395,8 +395,8 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 		}
 
 		@Throws(RpcErrorException::class, IOException::class, TimeoutException::class)
-		fun downloadFile(targetFilename: String, size: Int, dcId: Int, id: Long, accessHash: Long) {
-			val loc = TLInputDocumentFileLocation(id, accessHash)
+		fun downloadFile(targetFilename: String, size: Int, dcId: Int, id: Long, accessHash: Long, version: Int) {
+			val loc = TLInputDocumentFileLocation(id, accessHash, version)
 			downloadFileFromDc(targetFilename, loc, dcId, size)
 		}
 

--- a/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/DownloadManager.kt
@@ -434,6 +434,9 @@ class DownloadManager(internal var client: TelegramClient?, p: DownloadProgressI
 							continue // response is null since we didn't actually receive any data. Skip the rest of this iteration and try again.
 						} else if (e.getCode() == 400) {
 							//Somehow this file is broken. No idea why. Let's skip it for now
+							System.out.println("400 error code")
+							e.printStackTrace()
+							System.out.println("400 error code")
 							return false
 						} else {
 							throw e

--- a/src/main/kotlin/de/fabianonline/telegram_backup/mediafilemanager/DocumentFileManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/mediafilemanager/DocumentFileManager.kt
@@ -99,7 +99,7 @@ open class DocumentFileManager(msg: TLMessage, user: UserManager, client: Telegr
 	@Throws(RpcErrorException::class, IOException::class, TimeoutException::class)
 	override fun download() {
 		if (doc != null) {
-			DownloadManager.downloadFile(targetPathAndFilename, size, doc!!.getDcId(), doc!!.getId(), doc!!.getAccessHash())
+			DownloadManager.downloadFile(targetPathAndFilename, size, doc!!.getDcId(), doc!!.getId(), doc!!.getAccessHash(), doc!!.getVersion())
 		}
 	}
 }


### PR DESCRIPTION
Initial attempt to update telegram api layer and dependency. 

Version `1.0.0-RC2` seems to work with minimal changes, and seems the most promising for fixing my error. Going beyond that (`1.0.0-RC3` and `1.0.0-RC4`) cause many dependency errors.

Goal is to fix this error:

```
........   ......... .. . . ........ .  . .  .. .. .    ....  .. ..... ......  ...  ............ .  - 90800/121491
   .   .... ...  ........... .      ...  .  ...  ...  .    .. .       .  . .. ........ ...   ....... - 90900/121491
......................................................................... ...................... ... - 91000/121491
....... ......... ..  .     ..11:05:27.480 DEBUG DownloadManager.downloadFileFromDc : Downloading file /mnt/tgdata//+REDACTEDXXX/files/channel_1088057488_145.pdf
400 error code
400: DC_ID_INVALID
        at com.github.badoualy.telegram.api.DefaultTelegramClient.executeRpcQueries(DefaultTelegramClient.kt:209)
        at com.github.badoualy.telegram.api.DefaultTelegramClient.executeRpcQueries$default(DefaultTelegramClient.kt:181)
        at com.github.badoualy.telegram.api.DefaultTelegramClient.executeRpcQueries(DefaultTelegramClient.kt:160)
        at com.github.badoualy.telegram.api.TelegramClient$DefaultImpls.executeRpcQuery(TelegramClient.kt:53)
        at com.github.badoualy.telegram.api.DefaultTelegramClient.executeRpcQuery(DefaultTelegramClient.kt:157)
        at com.github.badoualy.telegram.tl.api.TelegramApiWrapper.authExportAuthorization(TelegramApiWrapper.java:213)
        at com.github.badoualy.telegram.api.DefaultTelegramClient.getExportedMTProtoHandler(DefaultTelegramClient.kt:293)
        at com.github.badoualy.telegram.api.DefaultTelegramClient.executeRpcQueries(DefaultTelegramClient.kt:200)
        at com.github.badoualy.telegram.api.DefaultTelegramClient.executeRpcQueries$default(DefaultTelegramClient.kt:181)
        at com.github.badoualy.telegram.api.DefaultTelegramClient.executeRpcQueries(DefaultTelegramClient.kt:171)
        at com.github.badoualy.telegram.api.TelegramClient$DefaultImpls.executeRpcQuery(TelegramClient.kt:56)
        at com.github.badoualy.telegram.api.DefaultTelegramClient.executeRpcQuery(DefaultTelegramClient.kt:25)
        at de.fabianonline.telegram_backup.DownloadManager$Companion.downloadFileFromDc(DownloadManager.kt:429)
        at de.fabianonline.telegram_backup.DownloadManager$Companion.downloadFile(DownloadManager.kt:399)
        at de.fabianonline.telegram_backup.mediafilemanager.DocumentFileManager.download(DocumentFileManager.kt:102)
        at de.fabianonline.telegram_backup.DownloadManager._downloadMedia(DownloadManager.kt:367)
        at de.fabianonline.telegram_backup.DownloadManager.downloadMedia(DownloadManager.kt:317)
        at de.fabianonline.telegram_backup.CommandLineController.<init>(CommandLineController.kt:138)
        at de.fabianonline.telegram_backup.CommandLineRunnerKt.main(CommandLineRunner.kt:40)
400 error code
D        .....  .. .... ..        .... ............ .............. . . - 91100/121491
. ...     . ...     ...  .. ...  .    .. . ..... . .... .. .. . .................. .....     .. ...e - 91200/121491-
```

Note: running this version requires a redownload of every media message due to the API layer being too old. This updates the api_layer for every entry in the messages table (where has_media=1) from 53 to 66. 

I'm not sure if some data is being lost in this transition...

@fabianonline what needs to change when updating the telegram api layer? Maybe new columns need to be added to the messages database. It's redownloading but nothing's changed, I think it's missing something.