### PR TITLE
Add missing ' character in log message

### DIFF
--- a/src/main/kotlin/de/fabianonline/telegram_backup/LoginManager.kt
+++ b/src/main/kotlin/de/fabianonline/telegram_backup/LoginManager.kt
@@ -40,7 +40,7 @@ class LoginManager(val app: TelegramApp, val target_dir: String, val phoneToUse:
 			val pw = getPassword()
 			verify_password(client, pw)
 		}
-		System.out.println("Everything seems fine. Please run this tool again with '--account ${phone} to use this account.")
+		System.out.println("Everything seems fine. Please run this tool again with '--account ${phone}' to use this account.")
 	}
 	
 	private fun send_code_to_phone_number(client: TelegramClient, phone: String): TLSentCode {


### PR DESCRIPTION
Before:
`Everything seems fine. Please run this tool again with '--account +4917077651234 to use this account.`

After:
`Everything seems fine. Please run this tool again with '--account +4917077651234' to use this account.`